### PR TITLE
add support of website urls

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3,7 +3,12 @@ window.handleOpenURL = function handleOpenURL(intent) {
   console.info('Triggered by intent:', intent);
   // Dont block the cordova plugins
   Meteor.defer(function () {
-    var parsedUrl = intent.match(intentPattern);
+
+    var parsedUrl = intent.match(urlPattern);
+
+    if(parsedUrl == null){
+       parsedUrl = intent.match(intentPattern);
+    }
 
     if (parsedUrl) {
       var [ /* url */ , name, /* path */ , base64, queryString] = parsedUrl;

--- a/lib/common.js
+++ b/lib/common.js
@@ -21,6 +21,16 @@ intentPattern = /([a-zA-Z0-9]+):(?:\/\/)?([a-zA-Z0-9\/]+)?(?:\?(?:data:ejson;(ba
 browserIntentPattern = /(?:.*):\/\/(?:[a-zA-Z0-9:\.])+\/((?:[a-zA-Z0-9]+):(?:\/\/)?(?:.*))/;
 
 /**
+ * Url pattern
+ *
+ * eg.:
+ * "http://foo.com/path?arguments"
+ *
+ * @type {RegExp}
+ */
+urlPattern =  /^(https?):\/\/?[\da-z\.-]+\.[a-z\.]{2,6}(.*)\/?$/;
+
+/**
  * Converts an object into a querystring
  * @param  {Object} obj) Source
  * @return {String}      Query string
@@ -201,4 +211,3 @@ DeepLink = class DeepLink {
   static once() { return eventState.once(...arguments); }
   static off() { return eventState.off(...arguments); }
 };
-


### PR DESCRIPTION
Hi,

in order to fix https://github.com/DispatchMe/meteor-deep-link/issues/5, I have added a check on url to handle website urls in the app.

Then with the two plugins

```
App.configurePlugin('cordova-plugin-customurlscheme', {
  URL_SCHEME: 'mycustomurl',
});

App.configurePlugin('cordova-yoik-intent-filter', {
  URL_SCHEME: 'https',
  HOST_NAME: 'my domain'
});
```

I am able to handle verify email links: 

```
  const verifyEmailPath = /^\/#\/verify-email\/(.*)\/?$/;

  DeepLink.on('https', (data, url, scheme, path) => {
    const token = path.match(verifyEmailPath);
    if (token) {
      Accounts.verifyEmail(token[1], (error) => {
        if (error) {
          Materialize.toast(T9n.get('An error has occured'), 5000);
        } else {
          Materialize.toast('Your mail is validated.') ;
          FlowRouter.go('/');
        }
      });
    }


    FlowRouter.go(path);
  });


```
