### PR TITLE
URL match breaks URLs with dashs

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -8,7 +8,7 @@
  *
  * @type {RegExp}
  */
-intentPattern = /([a-zA-Z0-9]+):(?:\/\/)?([a-zA-Z0-9\/]+)?(?:\?(?:data:ejson;(base64),)?(.*))?/;
+intentPattern = /([a-zA-Z0-9]+):(?:\/\/)?([a-zA-Z0-9\/-]+)?(?:\?(?:data:ejson;(base64),)?(.*))?/;
 
 /**
  * Browser intent pattern


### PR DESCRIPTION
The example URL is striped: 
"exampleApp:///reset-password/dlLs5Zklpve1Gd9HeUl3FTIAxzQxe4IcwbSJOmKr6CO".match(intentPattern)

The proposed changes should fix the problem.